### PR TITLE
fix vendor id/product id

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -10,7 +10,7 @@ from evdev.events import InputEvent
 
 _AbsInfo = namedtuple('AbsInfo', ['value', 'min', 'max', 'fuzz', 'flat', 'resolution'])
 _KbdInfo = namedtuple('KbdInfo', ['repeat', 'delay'])
-_DeviceInfo = namedtuple('DeviceInfo', ['bustype', 'product', 'vendor', 'version'])
+_DeviceInfo = namedtuple('DeviceInfo', ['bustype', 'vendor', 'product', 'version'])
 
 
 class AbsInfo(_AbsInfo):


### PR DESCRIPTION
Vendor ID and product ID, as reported by `DeviceInfo`, are reversed. This commit fixes that by switching the position of those two fields (`product` and `vendor`) in the `namedtuple` definition.

Test device:

```
$ sudo lsusb -d 6352: -v
Bus 001 Device 006: ID 6352:215a  
Device Descriptor:
  idVendor           0x6352 
  idProduct          0x215a 
```

Original evdev:

``` python
In [1]: from evdev import InputDevice
In [2]: inputdevice = InputDevice('/dev/input/event14')
In [3]: '{:04x}:{:04x}'.format(inputdevice.info.vendor, inputdevice.info.product)
Out[3]: '215a:6352'
```

Fixed evdev:

``` python
In [1]: from evdev import InputDevice
In [2]: inputdevice = InputDevice('/dev/input/event14')
In [3]: '{:04x}:{:04x}'.format(inputdevice.info.vendor, inputdevice.info.product)
Out[3]: '6352:215a'
```
