### PR TITLE
Add the LICENSE file to the manifest, so that sdist includes it in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 # make github and sdist happy
 include README.rst
 include evdev/ecodes.sh
+include LICENSE


### PR DESCRIPTION
When working on the Debian packaging, me and some Debian developers noticed that there is no copyright information in the source files. There is a LICENSE file in the git repository, but sadly that is not enough, as it is not exported into the source tarballs on sdist. That's why we need to include it in the MANIFEST.in.

I already made the same change in the packaging as a quilt patch, but now I need it to get included upstream. Could you approve? Copyright is important for Debian and Ubuntu.

Thanks!
