### PR TITLE
Fix minor typo in missing linux-headers message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def create_ecodes():
         install the headers for your kernel in order to continue:
 
             yum install kernel-headers-$(uname -r)
-            apt-get intall linux-headers-$(uname -r)
+            apt-get install linux-headers-$(uname -r)
             pacman -S kernel-headers\n\n'''
 
         sys.stderr.write(textwrap.dedent(msg))


### PR DESCRIPTION
`apt-get intall linux-headers` -> `apt-get install linux-headers`.
Spotted randomly when looking at setup.py for deps. Cheers!
