### PR TITLE
Support for read() operation on UInput

### DIFF
--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -37,7 +37,7 @@ uinput_open(PyObject *self, PyObject *args)
     int ret = PyArg_ParseTuple(args, "s", &devnode);
     if (!ret) return NULL;
 
-    int fd = open(devnode, O_WRONLY | O_NONBLOCK);
+    int fd = open(devnode, O_RDWR | O_NONBLOCK);
     if (fd < 0) {
         PyErr_SetString(PyExc_IOError, "could not open uinput device in write mode");
         return NULL;


### PR DESCRIPTION
This is necessary to support devices with EV_LED and EV_SND (Maybe others?)

This is related to the issue #45 I opened a few days ago.

Please notice that the implementation of `uinput.read()` is the same as `device.read()`.
I was a bit unconfortable with this until I notices that `device.set_led()` uses `_uinput.write`.

I believe that's OK, since both classes are perfectly symetric to each other