### PR TITLE
Generalization of `set_led()`

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -229,7 +229,18 @@ class InputDevice(object):
 
         ..
         '''
-        _uinput.write(self.fd, ecodes.EV_LED, led_num, value)
+        self.set(ecodes.EV_LED, led_num, value)
+
+    @need_write
+    def set(self, etype, code, value):
+        '''
+        Set the state of the selected component. For example::
+
+           device.set(ecodes.EV_LED, ecodes.LED_NUML, 1)
+
+        ..
+        '''
+        _uinput.write(self.fd, etype, code, value)
 
     def __eq__(self, other):
         '''Two devices are equal if their :data:`info` attributes are equal.'''


### PR DESCRIPTION
The device I'm working with supports SND_BELL, and I need an API for it.

We already have `set_led()`, but there are no API for other etypes.
Instead of adding `set_snd()`, etc, I suggest a generic `set()` method.