### PR TITLE
Support setting physical path ("phys") on UInput

### DIFF
--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -48,6 +48,27 @@ uinput_open(PyObject *self, PyObject *args)
 
 
 static PyObject *
+uinput_set_phys(PyObject *self, PyObject *args)
+{
+    int fd;
+    const char* phys;
+
+    int ret = PyArg_ParseTuple(args, "is", &fd, &phys);
+    if (!ret) return NULL;
+
+    if (ioctl(fd, UI_SET_PHYS, phys) < 0)
+        goto on_err;
+
+    Py_RETURN_NONE;
+
+    on_err:
+        _uinput_close(fd);
+        PyErr_SetFromErrno(PyExc_IOError);
+        return NULL;
+}
+
+
+static PyObject *
 uinput_create(PyObject *self, PyObject *args) {
     int fd, len, i, abscode;
     uint16_t vendor, product, version, bustype;
@@ -205,6 +226,9 @@ static PyMethodDef MethodTable[] = {
     { "enable", uinput_enable_event, METH_VARARGS,
       "Enable a type of event."},
 
+    { "set_phys", uinput_set_phys, METH_VARARGS,
+      "Set physical path"},
+      
     { NULL, NULL, 0, NULL}
 };
 

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -9,6 +9,7 @@ from evdev import ecodes, util, device
 from evdev.events import InputEvent
 from evdev.eventio import EventIO
 
+
 class UInputError(Exception):
     pass
 
@@ -28,7 +29,7 @@ class UInput(EventIO):
                  events=None,
                  name='py-evdev-uinput',
                  vendor=0x1, product=0x1, version=0x1, bustype=0x3,
-                 devnode='/dev/uinput'):
+                 devnode='/dev/uinput', phys='py-evdev-uinput'):
         '''
         Arguments
         ---------
@@ -52,6 +53,9 @@ class UInput(EventIO):
         bustype
           bustype identifier.
 
+        phys
+          physical path.
+          
         Note
         ----
         If you do not specify any events, the uinput device will be able
@@ -63,6 +67,7 @@ class UInput(EventIO):
         self.product = product   #: Device product identifier.
         self.version = version   #: Device version identifier.
         self.bustype = bustype   #: Device bustype - e.g. ``BUS_USB``.
+        self.phys    = phys      #: Uinput device physical path.
         self.devnode = devnode   #: Uinput device node - e.g. ``/dev/uinput/``.
 
         if not events:
@@ -76,6 +81,9 @@ class UInput(EventIO):
 
         #: Write-only, non-blocking file descriptor to the uinput device node.
         self.fd = _uinput.open(devnode)
+        
+        # Set phys name
+        _uinput.set_phys(self.fd, phys)
 
         # Set device capabilities.
         for etype, codes in events.items():
@@ -108,17 +116,17 @@ class UInput(EventIO):
     def __repr__(self):
         # TODO:
         v = (repr(getattr(self, i)) for i in
-             ('name', 'bustype', 'vendor', 'product', 'version'))
+             ('name', 'bustype', 'vendor', 'product', 'version', 'phys'))
         return '{}({})'.format(self.__class__.__name__, ', '.join(v))
 
     def __str__(self):
-        msg = ('name "{}", bus "{}", vendor "{:04x}", product "{:04x}", version "{:04x}"\n'
+        msg = ('name "{}", bus "{}", vendor "{:04x}", product "{:04x}", version "{:04x}", phys "{}"\n'
                'event types: {}')
 
         evtypes = [i[0] for i in self.capabilities(True).keys()]
         msg = msg.format(self.name, ecodes.BUS[self.bustype],
                          self.vendor, self.product,
-                         self.version, ' '.join(evtypes))
+                         self.version, self.phys, ' '.join(evtypes))
 
         return msg
 


### PR DESCRIPTION
`phys` is useful to distinguish 2 "identical" devices on the same host.