### PR TITLE
add python 3.6 classifier to setuptools and pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ classifiers = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Operating System :: POSIX :: Linux',
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
PyPI has a Python 3.6 trove classifier and evdev builds and runs under that version, amends metadata to reflect this.
