### PR TITLE
Provide access to bluetooth uniq address

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -107,7 +107,7 @@ class InputDevice(EventIO):
     A linux input device from which input events can be read.
     '''
 
-    __slots__ = ('fn', 'fd', 'info', 'name', 'phys', '_rawcapabilities',
+    __slots__ = ('fn', 'fd', 'info', 'name', 'phys', 'uniq', '_rawcapabilities',
                  'version', 'ff_effects_count')
 
     def __init__(self, dev):
@@ -142,6 +142,9 @@ class InputDevice(EventIO):
 
         #: The physical topology of the device.
         self.phys = info_res[5]
+
+	#: The unique address of the device
+        self.uniq = info_res[6]
 
         #: The evdev protocol version.
         self.version = _input.ioctl_EVIOCGVERSION(self.fd)

--- a/evdev/input.c
+++ b/evdev/input.c
@@ -216,6 +216,7 @@ ioctl_devinfo(PyObject *self, PyObject *args)
     struct input_id iid;
     char name[MAX_NAME_SIZE];
     char phys[MAX_NAME_SIZE] = {0};
+    char uniq[MAX_NAME_SIZE] = {0};
 
     int ret = PyArg_ParseTuple(args, "i", &fd);
     if (!ret) return NULL;
@@ -225,11 +226,13 @@ ioctl_devinfo(PyObject *self, PyObject *args)
     if (ioctl(fd, EVIOCGID, &iid) < 0)                 goto on_err;
     if (ioctl(fd, EVIOCGNAME(sizeof(name)), name) < 0) goto on_err;
 
+    ioctl(fd, EVIOCGUNIQ(sizeof(uniq)), uniq);
+
     // Some devices do not have a physical topology associated with them
     ioctl(fd, EVIOCGPHYS(sizeof(phys)), phys);
 
-    return Py_BuildValue("hhhhss", iid.bustype, iid.vendor, iid.product, iid.version,
-                         name, phys);
+    return Py_BuildValue("hhhhsss", iid.bustype, iid.vendor, iid.product, iid.version,
+                         name, phys, uniq);
 
     on_err:
         PyErr_SetFromErrno(PyExc_IOError);


### PR DESCRIPTION
See https://github.com/gvalkov/python-evdev/issues/81#issuecomment-375335531

Needed because some later kernels (at least from 4.15) have started reporting the bluetooth controller
MAC for bluetooth devices as the phys, rather than the actual physical address of the device (which is
obviously the bit you actually care about in most cases). As with phys, there's no guarantee that uniq
is actually set, so I'm treating it the same way as phys, but modern kernels appear to be putting the bluetooth destination HW address in uniq.