### PR TITLE
fix keyerror when filtering capabilities not present

### DIFF
--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -66,7 +66,8 @@ class UInput(EventIO):
                 all_capabilities[ev_type].update(ev_codes)
 
         for evtype in filtered_types:
-            del all_capabilities[evtype]
+            if evtype in all_capabilities:
+                del all_capabilities[evtype]
 
         return cls(events=all_capabilities, **kwargs)
 


### PR DESCRIPTION
`UIInput.from_device()` tries to remove events from the list of capabilities, even if they are not present in the device's capabilities.

This bit me in a situation that ended up being indicative of a bug in my own code, but one of the event types to be removed by default, (`EV_SYN` or `EV_FF`) was not in the device's list of capabilities, giving me a KeyError.
It seems that if the capability is not present, then it doesn't need to be removed from the capabilities dict. So I've made the removal conditional to prevent this raising a `KeyError`.