### PR TITLE
FIX: ensure lists handed in to _uinput.create are long enough

### DIFF
--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -139,6 +139,7 @@ class UInput(EventIO):
                     # Flatten (ABS_Y, (0, 255, 0, 0, 0, 0)) to (ABS_Y, 0, 255, 0, 0, 0, 0).
                     f = [code[0]]
                     f.extend(code[1])
+                    f.extend([0] * (6 - len(code[1])))
                     absinfo.append(f)
                     code = code[0]
 


### PR DESCRIPTION
This prevents a

E       SystemError: Objects/longobject.c:415: bad argument to internal function

when passing in too short of a list on newer versions of cpython.

The underlying issue is that in uinput.c:uinput_create the list access
is not checked for IndexError.  If out of range, it returns null and
sets an error.  At some point PyLong_AsLong started to fail when
passed null (rather than I assume treating it as 0).

This ensures filling with 0 behavior at the python level.