### PR TITLE
Use H to parse uinput_setup arguments

### DIFF
--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -84,7 +84,7 @@ uinput_setup(PyObject *self, PyObject *args) {
     struct uinput_user_dev uidev;
     const char* name;
 
-    int ret = PyArg_ParseTuple(args, "ishhhhO", &fd, &name, &vendor,
+    int ret = PyArg_ParseTuple(args, "isHHHHO", &fd, &name, &vendor,
                                &product, &version, &bustype, &absinfo);
     if (!ret) return NULL;
 


### PR DESCRIPTION
Since these arguments are treated as uint16_t values, using the 'H' specifier is more logical. Moreover, it allows vendor and product to be greater than or equal to 0x8000.