### PR TITLE
Add UInput support for the resolution parameter in AbsInfo

### DIFF
--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -93,7 +93,7 @@ uinput_setup(PyObject *self, PyObject *args) {
     // Setup absinfo:
     len = PyList_Size(absinfo);
     for (i=0; i<len; i++) {
-        
+
         // item -> (ABS_X, 0, 255, 0, 0, 0, 0)
         item = PyList_GetItem(absinfo, i);
 
@@ -113,7 +113,7 @@ uinput_setup(PyObject *self, PyObject *args) {
 
     // Setup evdev:
     struct uinput_setup usetup;
-    
+
     memset(&usetup, 0, sizeof(usetup));
     strncpy(usetup.name, name, sizeof(usetup.name) - 1);
     usetup.id.vendor  = vendor;
@@ -121,7 +121,6 @@ uinput_setup(PyObject *self, PyObject *args) {
     usetup.id.version = version;
     usetup.id.bustype = bustype;
     usetup.ff_effects_max = FF_MAX_EFFECTS;
-    ioctl(fd, UI_DEV_SETUP, &usetup);
 
     if(ioctl(fd, UI_DEV_SETUP, &usetup) < 0)
         goto on_err;


### PR DESCRIPTION
Creating a UInput device always ignored the resolution parameter since the c implementation was old for current linux kernels.

I've [a project](https://github.com/LinusCDE/rmTabletDriver) which creates a virtual tablet (absolute pen input). I'm currently working on getting the implementation working in libinput which turned out to be missing the resolution (which I had provided but was seemingly ignored by python-evdev).

This patch adds the capability to define the resolution using the newer way for defining absolute capabilities based on [my c implementation](https://github.com/LinusCDE/rmTabletDriver/blob/master/tabletDriver.c) to fix the problem.

If the new variant isn't supported by the kernel (e.g. old linux kernel or bsd), the current solution will still be used instead.

P.S.: I've never worked with c in python and not very much with c. So if anything is wrong please say so. I've successfully tested and verified this change in a virtual machine using Manjaro. I couldn't test other systems (bsd or old distro using older kernel).