### PR TITLE
Expose get/set absinfo ioctl commands

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -377,3 +377,53 @@ class InputDevice(EventIO):
         msg = 'Please use {0}.path instead of {0}.fn'.format(self.__class__.__name__)
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return self.path
+
+    def get_absinfo(self, axis_num):
+        """
+        Return current :class:`AbsInfo` for input device axis
+
+        Arguments
+        ---------
+        axis_num : int
+          EV_ABS keycode (example :attr:`ecodes.ABS_X`)
+
+        Example
+        -------
+
+        >>> device.get_absinfo(ecodes.ABS_X)
+        AbsInfo(value=1501, min=-32768, max=32767, fuzz=0, flat=128, resolution=0)
+
+        """
+        return AbsInfo(*_input.ioctl_EVIOCGABS(self.fd, axis_num))
+
+    def set_absinfo(self, axis_num, value=None, min=None, max=None, fuzz=None, flat=None, resolution=None):
+        """
+        Set AbsInfo values for input device.
+
+        Only values set will be overwritten.
+
+        See :class:`AbsInfo` for more info about the arguments
+
+        Arguments
+        ---------
+        axis_num : int
+          EV_ABS keycode (example :attr:`ecodes.ABS_X`)
+
+        Example
+        -------
+        >>> device.set_absinfo(ecodes.ABS_X, min=-2000, max=2000)
+
+        You can also unpack AbsInfo tuple that will overwrite all values
+
+        >>> device.set_absinfo(ecodes.ABS_Y, *AbsInfo(0, -2000, 2000, 0, 15, 0))
+
+
+        """
+        cur_absinfo = self.get_absinfo(axis_num)
+        new_absinfo = AbsInfo(value if value else cur_absinfo.value,
+                              min if min else cur_absinfo.min,
+                              max if max else cur_absinfo.max,
+                              fuzz if fuzz else cur_absinfo.fuzz,
+                              flat if flat else cur_absinfo.flat,
+                              resolution if resolution else cur_absinfo.resolution)
+        _input.ioctl_EVIOCSABS(self.fd, axis_num, new_absinfo)

--- a/evdev/input.c
+++ b/evdev/input.c
@@ -243,6 +243,63 @@ ioctl_devinfo(PyObject *self, PyObject *args)
 
 
 static PyObject *
+ioctl_EVIOCGABS(PyObject *self, PyObject *args)
+{
+    int fd, ev_code;
+    struct input_absinfo absinfo;
+    PyObject* py_absinfo = NULL;
+
+    int ret = PyArg_ParseTuple(args, "ii", &fd, &ev_code);
+    if (!ret) return NULL;
+
+    memset(&absinfo, 0, sizeof(absinfo));
+    ret = ioctl(fd, EVIOCGABS(ev_code), &absinfo);
+    if (ret == -1) {
+        PyErr_SetFromErrno(PyExc_IOError);
+        return NULL;
+    }
+
+    py_absinfo = Py_BuildValue("(iiiiii)",
+                               absinfo.value,
+                               absinfo.minimum,
+                               absinfo.maximum,
+                               absinfo.fuzz,
+                               absinfo.flat,
+                               absinfo.resolution);
+    return py_absinfo;
+}
+
+
+static PyObject *
+ioctl_EVIOCSABS(PyObject *self, PyObject *args)
+{
+    int fd, ev_code;
+    struct input_absinfo absinfo;
+
+    int ret = PyArg_ParseTuple(args,
+                               "ii(iiiiii)",
+                               &fd,
+                               &ev_code,
+                               &absinfo.value,
+                               &absinfo.minimum,
+                               &absinfo.maximum,
+                               &absinfo.fuzz,
+                               &absinfo.flat,
+                               &absinfo.resolution);
+    if (!ret) return NULL;
+
+    ret = ioctl(fd, EVIOCSABS(ev_code), &absinfo);
+    if (ret == -1) {
+        PyErr_SetFromErrno(PyExc_IOError);
+        return NULL;
+    }
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+static PyObject *
 ioctl_EVIOCGREP(PyObject *self, PyObject *args)
 {
     int fd, ret;
@@ -453,6 +510,8 @@ erase_effect(PyObject *self, PyObject *args)
 static PyMethodDef MethodTable[] = {
     { "ioctl_devinfo",        ioctl_devinfo,        METH_VARARGS, "fetch input device info" },
     { "ioctl_capabilities",   ioctl_capabilities,   METH_VARARGS, "fetch input device capabilities" },
+    { "ioctl_EVIOCGABS",      ioctl_EVIOCGABS,      METH_VARARGS, "get input device absinfo"},
+    { "ioctl_EVIOCSABS",      ioctl_EVIOCSABS,      METH_VARARGS, "set input device absinfo"},
     { "ioctl_EVIOCGREP",      ioctl_EVIOCGREP,      METH_VARARGS},
     { "ioctl_EVIOCSREP",      ioctl_EVIOCSREP,      METH_VARARGS},
     { "ioctl_EVIOCGVERSION",  ioctl_EVIOCGVERSION,  METH_VARARGS},


### PR DESCRIPTION
Changing AbsInfo data in kernel is useful for setting min/max
calibration for other programs and flatness/fuzz settings are
useful for kernel side filtering of input events