### PR TITLE
Make call to super() Python2-compatible

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -301,7 +301,7 @@ class InputDevice(EventIO):
     def close(self):
         if self.fd > -1:
             try:
-                super().close()
+                super(InputDevice, self).close()
                 os.close(self.fd)
             finally:
                 self.fd = -1


### PR DESCRIPTION
I was getting the following error with Python 2.7.17 on Ubuntu 18.04:

```
TypeError: 'super() takes at least 1 argument (0 given)'
```

I know [Python 2 has reached eol](https://www.python.org/doc/sunset-python-2/), but the README didn't seem to mention you're dropping support for Python 2 so I've submitted this PR. Thanks!