### PR TITLE
Fix set_absinfo to allow setting parameters to zero

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Master
+====================
+
+- Fix ``InputDevice.set_absinfo`` to allow setting parameters to zero.
+
+
 1.3.0 (Jan 12, 2020)
 ====================
 

--- a/evdev/device.py
+++ b/evdev/device.py
@@ -435,10 +435,10 @@ class InputDevice(EventIO):
         '''
 
         cur_absinfo = self.absinfo(axis_num)
-        new_absinfo = AbsInfo(value if value else cur_absinfo.value,
-                              min if min else cur_absinfo.min,
-                              max if max else cur_absinfo.max,
-                              fuzz if fuzz else cur_absinfo.fuzz,
-                              flat if flat else cur_absinfo.flat,
-                              resolution if resolution else cur_absinfo.resolution)
+        new_absinfo = AbsInfo(value if value is not None else cur_absinfo.value,
+                              min if min is not None else cur_absinfo.min,
+                              max if max is not None else cur_absinfo.max,
+                              fuzz if fuzz is not None else cur_absinfo.fuzz,
+                              flat if flat is not None else cur_absinfo.flat,
+                              resolution if resolution is not None else cur_absinfo.resolution)
         _input.ioctl_EVIOCSABS(self.fd, axis_num, new_absinfo)


### PR DESCRIPTION
It's impossible to set any of the AbsInfo parameters to 0 as it evaluate to False like None so the code was using the current value instead. The proposed fix simply check explicitly that the value is not None instead of false.