### PR TITLE
Fix off-by-one in ioctl_EVIOCG_bits

### DIFF
--- a/evdev/input.c
+++ b/evdev/input.c
@@ -413,7 +413,7 @@ ioctl_EVIOCG_bits(PyObject *self, PyObject *args)
         return NULL;
 
     PyObject* res = PyList_New(0);
-    for (int i=0; i<max; i++) {
+    for (int i=0; i<=max; i++) {
         if (test_bit(bytes, i)) {
             PyList_Append(res, Py_BuildValue("i", i));
         }


### PR DESCRIPTION
This bug caused values at the end of the list to not be reported back.

Example: On my system, SW_PEN_INSERTED (0x0f) is the last switch constant. That is,
SW_MAX=SW_PEN_INSERTED. Other tools (python-libevdev) correctly reported this switch
as 'set' but python-evdev did not. This commit fixes this issue.