### PR TITLE
Add missing return codes to os.strerror() calls and fix force feedback example in docs.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -385,7 +385,7 @@ Create ``uinput`` device capable of receiving FF-effects
             # Wait for an EV_UINPUT event that will signal us that an
             # effect upload/erase operation is in progress.
             if event.type != ecodes.EV_UINPUT:
-                pass
+                continue
 
             if event.code == ecodes.UI_FF_UPLOAD:
                 upload = device.begin_upload(event.value)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -391,7 +391,7 @@ Create ``uinput`` device capable of receiving FF-effects
                 upload = device.begin_upload(event.value)
                 upload.retval = 0
 
-                print(f'[upload] effect_id: {upload.effect_id}, type: {upload.effect.type}')
+                print(f'[upload] effect_id: {upload.effect.id}, type: {upload.effect.type}')
                 device.end_upload(upload)
 
             elif event.code == ecodes.UI_FF_ERASE:

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -229,26 +229,30 @@ class UInput(EventIO):
         upload = ff.UInputUpload()
         upload.effect_id = effect_id
 
-        if self.dll._uinput_begin_upload(self.fd, ctypes.byref(upload)):
-            raise UInputError('Failed to begin uinput upload: ' + os.strerror())
+        ret = self.dll._uinput_begin_upload(self.fd, ctypes.byref(upload))
+        if ret:
+            raise UInputError('Failed to begin uinput upload: ' + os.strerror(ret))
 
         return upload
 
     def end_upload(self, upload):
-        if self.dll._uinput_end_upload(self.fd, ctypes.byref(upload)):
-            raise UInputError('Failed to end uinput upload: ' + os.strerror())
+        ret = self.dll._uinput_end_upload(self.fd, ctypes.byref(upload))
+        if ret:
+            raise UInputError('Failed to end uinput upload: ' + os.strerror(ret))
 
     def begin_erase(self, effect_id):
         erase = ff.UInputErase()
         erase.effect_id = effect_id
 
-        if self.dll._uinput_begin_erase(self.fd, ctypes.byref(erase)):
-            raise UInputError('Failed to begin uinput erase: ' + os.strerror())
+        ret = self.dll._uinput_begin_erase(self.fd, ctypes.byref(erase))
+        if ret:
+            raise UInputError('Failed to begin uinput erase: ' + os.strerror(ret))
         return erase
 
     def end_erase(self, erase):
-        if self.dll._uinput_end_erase(self.fd, ctypes.byref(erase)):
-            raise UInputError('Failed to end uinput erase: ' + os.strerror())
+        ret = self.dll._uinput_end_erase(self.fd, ctypes.byref(erase))
+        if ret:
+            raise UInputError('Failed to end uinput erase: ' + os.strerror(ret))
 
     def _verify(self):
         '''


### PR DESCRIPTION
Fixes code bug discussed in #135 

Minimal change, but do let me know if you'd like it done differently! I briefly tested this on my machine and it works as expected.