### PR TITLE
threaded non-blocking close

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -4,6 +4,7 @@ import os
 import warnings
 import contextlib
 import collections
+import threading
 
 from evdev import _input, ecodes, util
 from evdev.events import InputEvent
@@ -302,7 +303,7 @@ class InputDevice(EventIO):
         if self.fd > -1:
             try:
                 super().close()
-                os.close(self.fd)
+                threading.Thread(target=os.close, args=(self.fd,)).start()
             finally:
                 self.fd = -1
 

--- a/evdev/device.py
+++ b/evdev/device.py
@@ -303,6 +303,8 @@ class InputDevice(EventIO):
         if self.fd > -1:
             try:
                 super().close()
+                # avoid blocking at the end of functions when the destructor
+                # is called.
                 threading.Thread(target=os.close, args=(self.fd,)).start()
             finally:
                 self.fd = -1


### PR DESCRIPTION
see https://github.com/gvalkov/python-evdev/issues/144

I don't know if the rest of the code relies on a blocking os.close, but it solves my issue. It doesn't seem to cause any unwanted side effects in my use case (https://github.com/sezanzeb/key-mapper), everything works fine.