### PR TITLE
fixing "There is no current event loop in thread" for non asyncio code

### DIFF
--- a/evdev/eventio_async.py
+++ b/evdev/eventio_async.py
@@ -56,7 +56,7 @@ class EventIO(eventio.EventIO):
             loop.remove_reader(self.fileno())
         except RuntimeError:
             # no event loop present, so there is nothing to
-            # remove the header from. ignore
+            # remove the reader from. Ignore
             pass
 
 

--- a/evdev/eventio_async.py
+++ b/evdev/eventio_async.py
@@ -51,8 +51,13 @@ class EventIO(eventio.EventIO):
         return ReadIterator(self)
 
     def close(self):
-        loop = asyncio.get_event_loop()
-        loop.remove_reader(self.fileno())
+        try:
+            loop = asyncio.get_event_loop()
+            loop.remove_reader(self.fileno())
+        except RuntimeError:
+            # no event loop present, so there is nothing to
+            # remove the header from. ignore
+            pass
 
 
 class ReadIterator(object):


### PR DESCRIPTION
fixes https://github.com/lutris/lutris/issues/3250

_do_when_readable is only used for e.g. async_read, but InputDevice may not use that and use read instead. So _do_when_readable is never called and no event loop is needed.