### PR TITLE
ff: Fix up attack_length key typo in Envelope struct

### DIFF
--- a/evdev/ff.py
+++ b/evdev/ff.py
@@ -51,7 +51,7 @@ class Envelope(ctypes.Structure):
     '''
 
     _fields_ = [
-        ('attach_length', _u16),
+        ('attack_length', _u16),
         ('attack_level', _u16),
         ('fade_length', _u16),
         ('fade_level', _u16),


### PR DESCRIPTION
The Envelope struct defined an 'attach_length' key instead of the
expected 'attack_length'. While the documentation was correct, any
passed in 'attack_length' value was being silently dropped.

This was discovered when configuring a periodic sinusoidal effect
and observing differences in the waveform in comparison to the C API.

Signed-off-by: Paul Mundt <paul.mundt@adaptant.io>