### PR TITLE
Fix regex search

### DIFF
--- a/evdev/util.py
+++ b/evdev/util.py
@@ -118,6 +118,8 @@ def find_ecodes_by_regex(regex):
     '''
     Find ecodes matching a regex and return a mapping of event type to event codes.
 
+    regex can be a pattern string or a compiled regular expression object.
+
     Example
     -------
     >>> find_ecodes_by_regex(r'(ABS|KEY)_BR(AKE|EAK)')
@@ -130,7 +132,7 @@ def find_ecodes_by_regex(regex):
     }
     '''
 
-    regex = regex if isinstance(regex, re.Pattern) else re.compile(regex)
+    regex = re.compile(regex)  # re.compile is idempotent
     result = collections.defaultdict(list)
 
     for type_code, codes in ecodes.bytype.items():


### PR DESCRIPTION
re.Pattern is not a guaranteed class name of the re module:

```
[   32s] _____________________________ test_match_ecodes_a ______________________________
[   32s] 
[   32s]     def test_match_ecodes_a():
[   32s] >       res = util.find_ecodes_by_regex('KEY_ZOOM.*')
[   32s] 
[   32s] tests/test_util.py:5: 
[   32s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   32s] 
[   32s] regex = 'KEY_ZOOM.*'
[   32s] 
[   32s]     def find_ecodes_by_regex(regex):
[   32s]         '''
[   32s]         Find ecodes matching a regex and return a mapping of event type to event codes.
[   32s]     
[   32s]         Example
[   32s]         -------
[   32s]         >>> find_ecodes_by_regex(r'(ABS|KEY)_BR(AKE|EAK)')
[   32s]         {1: [411], 3: [10]}
[   32s]         >>> res = find_ecodes_by_regex(r'(ABS|KEY)_BR(AKE|EAK)')
[   32s]         >>> resolve_ecodes_dict(res)
[   32s]         {
[   32s]             ('EV_KEY', 1): [('KEY_BREAK', 411)],
[   32s]             ('EV_ABS', 3): [('ABS_BRAKE', 10)]
[   32s]         }
[   32s]         '''
[   32s]     
[   32s] >       regex = regex if isinstance(regex, re.Pattern) else re.compile(regex)
[   32s] E       AttributeError: module 're' has no attribute 'Pattern'
```

```pycon
[ben@skylab:…c/python-evdev]% python2                                                                        [0]
Python 2.7.18 (default, Apr 23 2020, 09:27:04) [GCC] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.Pattern
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'Pattern'
>>> x = re.compile('match.*this')
>>> x
<_sre.SRE_Pattern object at 0x7f8c73b4de30>
>>> x.match("matching this")
<_sre.SRE_Match object at 0x7f8c73a16110>
>>> x2 = re.compile(x)
>>> x2.match("matching this")
<_sre.SRE_Match object at 0x7f8c73a16180>
>>> 
[ben@skylab:…c/python-evdev]% python3.6                                                                      [0]
Python 3.6.13 (default, Feb 19 2021, 18:59:35) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.Pattern
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 're' has no attribute 'Pattern'
>>> x = re.compile('match.*this')
>>> x
re.compile('match.*this')
>>> type(x)
<class '_sre.SRE_Pattern'>
>>> x.match("matching this")
<_sre.SRE_Match object; span=(0, 13), match='matching this'>
>>> x2 = re.compile(x)
>>> x2.match("matching this")
<_sre.SRE_Match object; span=(0, 13), match='matching this'>
>>> 
[ben@skylab:…c/python-evdev]% python3.8                                                                      [0]
Python 3.8.8 (default, Feb 19 2021, 16:53:21) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.Pattern
<class 're.Pattern'>
>>> x = re.compile('match.*this')
>>> x
re.compile('match.*this')
>>> type(x)
<class 're.Pattern'>
>>> x.match("matching this")
<re.Match object; span=(0, 13), match='matching this'>
>>> x2 = re.compile(x)
>>> x2.match("matching this")
<re.Match object; span=(0, 13), match='matching this'>
>>> 
```