### PR TITLE
fix ImportError: sys.meta_path is None

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -158,7 +158,7 @@ class InputDevice(EventIO):
         if hasattr(self, 'fd') and self.fd is not None:
             try:
                 self.close()
-            except OSError:
+            except (OSError, ImportError):
                 pass
 
     def _capabilities(self, absinfo=True):

--- a/evdev/device.py
+++ b/evdev/device.py
@@ -158,7 +158,7 @@ class InputDevice(EventIO):
         if hasattr(self, 'fd') and self.fd is not None:
             try:
                 self.close()
-            except (OSError, ImportError):
+            except (OSError, ImportError, AttributeError):
                 pass
 
     def _capabilities(self, absinfo=True):


### PR DESCRIPTION
Fix ImportError, AttributeError, maybe a generic Exception is more pratical

```
Exception ignored in: <bound method InputDevice.__del__ of InputDevice('/dev/input/event12')>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/evdev/device.py", line 160, in __del__
  File "/usr/local/lib/python3.6/dist-packages/evdev/device.py", line 305, in close
  File "/usr/local/lib/python3.6/dist-packages/evdev/eventio_async.py", line 55, in close
  File "/usr/lib/python3.6/asyncio/events.py", line 694, in get_event_loop
  File "/usr/lib/python3.6/asyncio/events.py", line 669, in get_event_loop_policy
  File "/usr/lib/python3.6/asyncio/events.py", line 662, in _init_event_loop_policy
ImportError: sys.meta_path is None, Python is likely shutting down
```