### PR TITLE
evdev/eventio_async.py: python3.11 compatibility

### DIFF
--- a/evdev/eventio_async.py
+++ b/evdev/eventio_async.py
@@ -85,8 +85,7 @@ class ReadIterator(object):
     def __aiter__(self):
         return self
 
-    @asyncio.coroutine
-    def __anext__(self):
+    async def __anext__(self):
         future = asyncio.Future()
         try:
             # Read from the previous batch of events.


### PR DESCRIPTION
From the [Python 3.11 Changelog](https://docs.python.org/3.11/whatsnew/3.11.html):

>The @asyncio.coroutine [decorator](https://docs.python.org/3.11/glossary.html#term-decorator) enabling legacy generator-based coroutines to be compatible with async/await code. The function has been deprecated since Python 3.8 and the removal was initially scheduled for Python 3.10. Use [async def](https://docs.python.org/3.11/reference/compound_stmts.html#async-def) instead. (Contributed by Illia Volochii in [bpo-43216](https://bugs.python.org/issue?@action=redirect&bpo=43216).)

This small change should make things work with python 3.11, the tests are passing for me.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>