### PR TITLE
Put unused variable to use

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -445,7 +445,7 @@ Injecting an FF-event into first FF-capable device found
         ecodes.FF_RUMBLE, -1, 0,
         ff.Trigger(0, 0),
         ff.Replay(duration_ms, 0),
-        ff.EffectType(ff_rumble_effect=rumble)
+        effect_type
     )
 
     repeat_count = 1


### PR DESCRIPTION
Variable `effect_type` was declared but never used, in the ff-event injection example.