### PR TITLE
Add blockless read loop feature at eventIO

### DIFF
--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -77,12 +77,12 @@ class EventIO:
         
             try:
                 if present_event[2] + present_event[3] + present_event[4] != nothing:
-                    yield evdev.events.InputEvent(*present_event)
+                    yield InputEvent(*present_event)
         
                 else:
-                    yield evdev.events.InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
+                    yield InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
             except TypeError:
-                yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
+                yield InputEvent(previous1, previous2, previous3, previous4, previous5)
 
         while True:
             # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -47,51 +47,51 @@ class EventIO:
                 yield event
 
 	def read_loop_blockless(self):
-	    '''
-	            Enter a blockless :func:`select.select()` loop that yields input events endlessly.
-	    '''
+		'''
+				Enter a blockless :func:`select.select()` loop that yields input events endlessly.
+		'''
 
-	    # previous -> [sec, usec, type, code, val]
-	    previous = [0, 0, 0, 0, 0]
+		# previous -> [sec, usec, type, code, val]
+		previous = [0, 0, 0, 0, 0]
 
-	    # flag for 0
-	    nothing = 0
+		# flag for 0
+		nothing = 0
 
-	    '''
-	            It is different from it's blocking counterpart because it does not stop the execution when the device is
-	            idle, instead it replicates the previous event until another one happens. This is made possible by
-                making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
-                are no available events at the moment.
-	    '''
+		'''
+				It is different from it's blocking counterpart because it does not stop the execution when the device is
+				idle, instead it replicates the previous event until another one happens. This is made possible by
+				making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
+				are no available events at the moment.
+		'''
 
-	    def read_blockless(previous1, previous2, previous3, previous4, previous5):
-	        '''
-	                Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
+		def read_blockless(previous1, previous2, previous3, previous4, previous5):
+			'''
+					Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
 
-	                Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
-	                no pending input events.
-	        '''
+					Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
+					no pending input events.
+			'''
 
-	        # event -> (sec, usec, type, code, val)
-	        present_event = _input.device_read(self.fd)
+			# event -> (sec, usec, type, code, val)
+			present_event = _input.device_read(self.fd)
 
-	        try:
-	            if present_event[2] + present_event[3] + present_event[4] != nothing:
-	                yield evdev.events.InputEvent(*present_event)
+			try:
+				if present_event[2] + present_event[3] + present_event[4] != nothing:
+					yield evdev.events.InputEvent(*present_event)
 
-	            else:
-	                yield evdev.events.InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
-	        except TypeError:
-	            yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
+				else:
+					yield evdev.events.InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
+			except TypeError:
+				yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
 
-	    while True:
-	        # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
-	        select([self.fd], [], [], nothing)
+		while True:
+			# selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
+			select([self.fd], [], [], nothing)
 
-	        for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
-	            previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type,\
-	                                                                              event.code, event.value
-	            yield event
+			for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
+				previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type,\
+																				  event.code, event.value
+				yield event
 
 
     def read_one(self):

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -46,52 +46,52 @@ class EventIO:
             for event in self.read():
                 yield event
 
-	def read_loop_blockless(self):
-		'''
-				Enter a blockless :func:`select.select()` loop that yields input events endlessly.
-		'''
+   def read_loop_blockless(self):
+        '''
+                Enter a blockless :func:`select.select()` loop that yields input events endlessly.
+        '''
+        
+        # previous -> [sec, usec, type, code, val]
+        previous = [0, 0, 0, 0, 0]
+        
+        # flag for 0
+        nothing = 0
+        
+        '''
+                It is different from it's blocking counterpart because it does not stop the execution when the device is
+                idle, instead it replicates the previous event until another one happens. This is made possible by
+                making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
+                are no available events at the moment.
+        '''
+        
+        def read_blockless(previous1, previous2, previous3, previous4, previous5):
+            '''
+                    Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
+        
+                    Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
+                    no pending input events.
+            '''
+        
+            # event -> (sec, usec, type, code, val)
+            present_event = _input.device_read(self.fd)
+        
+            try:
+                if present_event[2] + present_event[3] + present_event[4] != nothing:
+                    yield evdev.events.InputEvent(*present_event)
+        
+                else:
+                    yield evdev.events.InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
+            except TypeError:
+                yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
 
-		# previous -> [sec, usec, type, code, val]
-		previous = [0, 0, 0, 0, 0]
+while True:
+    # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
+    select([self.fd], [], [], nothing)
 
-		# flag for 0
-		nothing = 0
-
-		'''
-				It is different from it's blocking counterpart because it does not stop the execution when the device is
-				idle, instead it replicates the previous event until another one happens. This is made possible by
-				making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
-				are no available events at the moment.
-		'''
-
-		def read_blockless(previous1, previous2, previous3, previous4, previous5):
-			'''
-					Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
-
-					Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
-					no pending input events.
-			'''
-
-			# event -> (sec, usec, type, code, val)
-			present_event = _input.device_read(self.fd)
-
-			try:
-				if present_event[2] + present_event[3] + present_event[4] != nothing:
-					yield evdev.events.InputEvent(*present_event)
-
-				else:
-					yield evdev.events.InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
-			except TypeError:
-				yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
-
-		while True:
-			# selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
-			select([self.fd], [], [], nothing)
-
-			for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
-				previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type,\
-																				  event.code, event.value
-				yield event
+    for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
+        previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type,\
+                                                                          event.code, event.value
+        yield event
 
 
     def read_one(self):

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -86,7 +86,7 @@ class EventIO:
 
         while True:
             # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
-            select([self.fd], [], [], nothing)
+            select.select([self.fd], [], [], nothing)
         
             for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
                 previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type, event.code, event.value

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -48,7 +48,7 @@ class EventIO:
 
     def read_loop_blockless(self):
         '''
-                Enter a blockless :func:`select.select()` loop that yields input events endlessly.
+        Enter a blockless :func:`select.select()` loop that yields input events endlessly.
         '''
         
         # previous -> [sec, usec, type, code, val]
@@ -58,18 +58,18 @@ class EventIO:
         nothing = 0
         
         '''
-                It is different from it's blocking counterpart because it does not stop the execution when the device is
-                idle, instead it replicates the previous event until another one happens. This is made possible by
-                making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
-                are no available events at the moment.
+        It is different from it's blocking counterpart because it does not stop the execution when the device is
+        idle, instead it replicates the previous event until another one happens. This is made possible by
+        making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
+        are no available events at the moment.
         '''
         
         def read_blockless(previous1, previous2, previous3, previous4, previous5):
             '''
-                    Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
-        
-                    Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
-                    no pending input events.
+            Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
+
+            Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
+            no pending input events.
             '''
         
             # event -> (sec, usec, type, code, val)
@@ -84,15 +84,13 @@ class EventIO:
             except TypeError:
                 yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
 
-while True:
-    # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
-    select([self.fd], [], [], nothing)
-
-    for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
-        previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type,\
-                                                                          event.code, event.value
-        yield event
-
+        while True:
+            # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
+            select([self.fd], [], [], nothing)
+        
+            for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
+                previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type, event.code, event.value
+                yield event
 
     def read_one(self):
         '''

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -46,6 +46,54 @@ class EventIO:
             for event in self.read():
                 yield event
 
+	def read_loop_blockless(self):
+	    '''
+	            Enter a blockless :func:`select.select()` loop that yields input events endlessly.
+	    '''
+
+	    # previous -> [sec, usec, type, code, val]
+	    previous = [0, 0, 0, 0, 0]
+
+	    # flag for 0
+	    nothing = 0
+
+	    '''
+	            It is different from it's blocking counterpart because it does not stop the execution when the device is
+	            idle, instead it replicates the previous event until another event happens. This is made possible by
+                making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
+                are no available events at the moment.
+	    '''
+
+	    def read_blockless(previous1, previous2, previous3, previous4, previous5):
+	        '''
+	                Read and yield a single input event as an instance of :class:`InputEvent <evdev.events.InputEvent>`.
+
+	                Return previous event as an instance of :class:`InputEvent <evdev.events.InputEvent>` if there are
+	                no pending input events.
+	        '''
+
+	        # event -> (sec, usec, type, code, val)
+	        present_event = _input.device_read(self.fd)
+
+	        try:
+	            if present_event[2] + present_event[3] + present_event[4] != nothing:
+	                yield evdev.events.InputEvent(*present_event)
+
+	            else:
+	                yield evdev.events.InputEvent(present_event[0], present_event[1], previous3, previous4, previous5)
+	        except TypeError:
+	            yield evdev.events.InputEvent(previous1, previous2, previous3, previous4, previous5)
+
+	    while True:
+	        # selecting device and setting timeout to 0 / nothing, thus allowing non-blocking feature
+	        select([self.fd], [], [], nothing)
+
+	        for event in read_blockless(previous[0], previous[1], previous[2], previous[3], previous[4]):
+	            previous[0], previous[1], previous[2], previous[3], previous[4] = event.usec, event.sec, event.type,\
+	                                                                              event.code, event.value
+	            yield event
+
+
     def read_one(self):
         '''
         Read and return a single input event as an instance of

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -46,7 +46,7 @@ class EventIO:
             for event in self.read():
                 yield event
 
-   def read_loop_blockless(self):
+    def read_loop_blockless(self):
         '''
                 Enter a blockless :func:`select.select()` loop that yields input events endlessly.
         '''

--- a/evdev/eventio.py
+++ b/evdev/eventio.py
@@ -59,7 +59,7 @@ class EventIO:
 
 	    '''
 	            It is different from it's blocking counterpart because it does not stop the execution when the device is
-	            idle, instead it replicates the previous event until another event happens. This is made possible by
+	            idle, instead it replicates the previous event until another one happens. This is made possible by
                 making use of a custom :func: 'read_blockless()' function that doesn't raise 'BlockingIOError' if there
                 are no available events at the moment.
 	    '''


### PR DESCRIPTION
Added a blockless read loop feature to the eventIO module. That would help devs that need to constantly use devices' events info, e.g., moving a mouse with an analog stick. 