### PR TITLE
respect CPATH/C_INCLUDE_PATH

### DIFF
--- a/evdev/genecodes.py
+++ b/evdev/genecodes.py
@@ -13,6 +13,7 @@ import os, sys, re
 headers = [
     '/usr/include/linux/input.h',
     '/usr/include/linux/input-event-codes.h',
+    '/usr/include/linux/uinput.h',
 ]
 
 if sys.argv[1:]:

--- a/setup.py
+++ b/setup.py
@@ -64,11 +64,14 @@ kw = {
 #-----------------------------------------------------------------------------
 def create_ecodes(headers=None):
     if not headers:
-        headers = [
-            '/usr/include/linux/input.h',
-            '/usr/include/linux/input-event-codes.h',
-            '/usr/include/linux/uinput.h',
-        ]
+        include_paths = set()
+        if os.environ.get("CPATH", "").strip() != "":
+            include_paths.update(os.environ["CPATH"].split(":"))
+        if os.environ.get("C_INCLUDE_PATH", "").strip() != "":
+            include_paths.update(os.environ["C_INCLUDE_PATH"].split(":"))
+        include_paths.add("/usr/include")
+        files = ["linux/input.h", "linux/input-event-codes.h", "linux/uinput.h"]
+        headers = [os.path.join(path, file) for path in include_paths for file in files]
 
     headers = [header for header in headers if os.path.isfile(header)]
     if not headers:


### PR DESCRIPTION
Flags are hard to pass when python-evdev is installed as part of another python library. Instead evdev should check standard environment variables that also a C compiler would use to locate a header file.

See: https://gcc.gnu.org/onlinedocs/cpp/Environment-Variables.html