### PR TITLE
Set ff_effects_max correctly by subtracting FF_EFFECT_MIN.

### DIFF
--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -108,14 +108,15 @@ static PyObject *
 uinput_setup(PyObject *self, PyObject *args) {
     int fd, len, i;
     uint16_t vendor, product, version, bustype;
+    uint32_t max_effects;
 
     PyObject *absinfo = NULL, *item = NULL;
 
     struct uinput_abs_setup abs_setup;
 
     const char* name;
-    int ret = PyArg_ParseTuple(args, "isHHHHO", &fd, &name, &vendor,
-                               &product, &version, &bustype, &absinfo);
+    int ret = PyArg_ParseTuple(args, "isHHHHOI", &fd, &name, &vendor,
+                               &product, &version, &bustype, &absinfo, &max_effects);
     if (!ret) return NULL;
 
     // Setup absinfo:
@@ -147,7 +148,7 @@ uinput_setup(PyObject *self, PyObject *args) {
     usetup.id.product = product;
     usetup.id.version = version;
     usetup.id.bustype = bustype;
-    usetup.ff_effects_max = FF_MAX_EFFECTS - FF_EFFECT_MIN;
+    usetup.ff_effects_max = max_effects;
 
     if(ioctl(fd, UI_DEV_SETUP, &usetup) < 0)
         goto on_err;
@@ -166,14 +167,15 @@ static PyObject *
 uinput_setup(PyObject *self, PyObject *args) {
     int fd, len, i, abscode;
     uint16_t vendor, product, version, bustype;
+    uint32_t max_effects;
 
     PyObject *absinfo = NULL, *item = NULL;
 
     struct uinput_user_dev uidev;
     const char* name;
 
-    int ret = PyArg_ParseTuple(args, "isHHHHO", &fd, &name, &vendor,
-                               &product, &version, &bustype, &absinfo);
+    int ret = PyArg_ParseTuple(args, "isHHHHOI", &fd, &name, &vendor,
+                               &product, &version, &bustype, &absinfo, &max_effects);
     if (!ret) return NULL;
 
     memset(&uidev, 0, sizeof(uidev));
@@ -182,7 +184,7 @@ uinput_setup(PyObject *self, PyObject *args) {
     uidev.id.product = product;
     uidev.id.version = version;
     uidev.id.bustype = bustype;
-    uidev.ff_effects_max = FF_MAX_EFFECTS - FF_EFFECT_MIN;
+    uidev.ff_effects_max = max_effects;
 
     len = PyList_Size(absinfo);
     for (i=0; i<len; i++) {

--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -147,7 +147,7 @@ uinput_setup(PyObject *self, PyObject *args) {
     usetup.id.product = product;
     usetup.id.version = version;
     usetup.id.bustype = bustype;
-    usetup.ff_effects_max = FF_MAX_EFFECTS;
+    usetup.ff_effects_max = FF_MAX_EFFECTS - FF_EFFECT_MIN;
 
     if(ioctl(fd, UI_DEV_SETUP, &usetup) < 0)
         goto on_err;
@@ -182,7 +182,7 @@ uinput_setup(PyObject *self, PyObject *args) {
     uidev.id.product = product;
     uidev.id.version = version;
     uidev.id.bustype = bustype;
-    uidev.ff_effects_max = FF_MAX_EFFECTS;
+    uidev.ff_effects_max = FF_MAX_EFFECTS - FF_EFFECT_MIN;
 
     len = PyList_Size(absinfo);
     for (i=0; i<len; i++) {

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -108,6 +108,9 @@ class UInput(EventIO):
         input_props
           Input properties and quirks.
 
+        max_effects
+          Maximum simultaneous force-feedback effects.
+
         Note
         ----
         If you do not specify any events, the uinput device will be able

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -59,6 +59,9 @@ class UInput(EventIO):
 
         all_capabilities = defaultdict(set)
 
+        if 'max_effects' not in kwargs:
+            kwargs['max_effects'] = min([dev.ff_effects_count for dev in device_instances])
+
         # Merge the capabilities of all devices into one dictionary.
         for dev in device_instances:
             for ev_type, ev_codes in dev.capabilities().items():

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -74,7 +74,8 @@ class UInput(EventIO):
                  events=None,
                  name='py-evdev-uinput',
                  vendor=0x1, product=0x1, version=0x1, bustype=0x3,
-                 devnode='/dev/uinput', phys='py-evdev-uinput', input_props=None):
+                 devnode='/dev/uinput', phys='py-evdev-uinput', input_props=None,
+                 max_effects=ecodes.FF_MAX_EFFECTS):
         '''
         Arguments
         ---------
@@ -140,7 +141,7 @@ class UInput(EventIO):
         for etype, code in prepared_events:
             _uinput.enable(self.fd, etype, code)
 
-        _uinput.setup(self.fd, name, vendor, product, version, bustype, absinfo)
+        _uinput.setup(self.fd, name, vendor, product, version, bustype, absinfo, max_effects)
 
         # Create the uinput device.
         _uinput.create(self.fd)


### PR DESCRIPTION
Hi, I believe there is a bug as far as setting ff_effects_max when creating ff-capable uinput devices.

Opening a controller device with fftest, I am told.. `Number of simultaneous effects: 16`. With python-evdev I create a uinput device that copies the exact capabilities of this device. For this device, fftest reports.. `Number of simultaneous effects: 96`. Off by 80. 

In the kernel [input.h](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/input.h), I can see `FF_EFFECT_MIN` and `FF_RUMBLE` is defined as 0x50 (80), and represents the offset to calculate the actual number of effects. So FF_EFFECT_MIN should be subtracted from FF_MAX_EFFECTS to set the value expected in ff_effects_max.

This pull request makes the described change in python-evdev's `uinput.c`. With the change, a copied device will report the correct number of simultaneous effects.