### PR TITLE
Print uniq additionally to phys, if available

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -283,8 +283,9 @@ class InputDevice(EventIO):
             and self.path == other.path
 
     def __str__(self):
-        msg = 'device {}, name "{}", phys "{}"'
-        return msg.format(self.path, self.name, self.uniq if self.uniq else self.phys)
+        msg = 'device {}, name "{}", phys "{}"{}'
+        uniq = ', uniq "{}"'.format(self.uniq) if self.uniq else ''
+        return msg.format(self.path, self.name, self.phys, uniq)
 
     def __repr__(self):
         msg = (self.__class__.__name__, self.path)

--- a/evdev/device.py
+++ b/evdev/device.py
@@ -284,7 +284,7 @@ class InputDevice(EventIO):
 
     def __str__(self):
         msg = 'device {}, name "{}", phys "{}"'
-        return msg.format(self.path, self.name, self.phys)
+        return msg.format(self.path, self.name, self.uniq if self.uniq else self.phys)
 
     def __repr__(self):
         msg = (self.__class__.__name__, self.path)


### PR DESCRIPTION
Hi there, I think in most cases it's rather uniq instead of phys one is interested in. E.g., for Bluetooth devices, phys shows the own device's Bluetooth adapter MAC, which is the same for all input devices, whereas uniq shows each device's individual MAC.