### PR TITLE
New method for finding the device node corresponding to a uinput device

### DIFF
--- a/evdev/device.py
+++ b/evdev/device.py
@@ -309,7 +309,7 @@ class InputDevice(EventIO):
 
         Warning
         -------
-        Grabbing an already grabbed device will raise an ``IOError``.
+        Grabbing an already grabbed device will raise an ``OSError``.
         '''
 
         _input.ioctl_EVIOCGRAB(self.fd, 1)
@@ -321,7 +321,7 @@ class InputDevice(EventIO):
         Warning
         -------
         Releasing an already released device will raise an
-        ``IOError('Invalid argument')``.
+        ``OSError('Invalid argument')``.
         '''
 
         _input.ioctl_EVIOCGRAB(self.fd, 0)

--- a/evdev/input.c
+++ b/evdev/input.c
@@ -61,7 +61,7 @@ device_read(PyObject *self, PyObject *args)
             return Py_None;
         }
 
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -101,7 +101,7 @@ device_read_many(PyObject *self, PyObject *args)
     ssize_t nread = read(fd, event, event_size*64);
 
     if (nread < 0) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         Py_DECREF(event_list);
         return NULL;
     }
@@ -208,7 +208,7 @@ ioctl_capabilities(PyObject *self, PyObject *args)
     return capabilities;
 
     on_err:
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -243,7 +243,7 @@ ioctl_devinfo(PyObject *self, PyObject *args)
                          name, phys, uniq);
 
     on_err:
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -261,7 +261,7 @@ ioctl_EVIOCGABS(PyObject *self, PyObject *args)
     memset(&absinfo, 0, sizeof(absinfo));
     ret = ioctl(fd, EVIOCGABS(ev_code), &absinfo);
     if (ret == -1) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -296,7 +296,7 @@ ioctl_EVIOCSABS(PyObject *self, PyObject *args)
 
     ret = ioctl(fd, EVIOCSABS(ev_code), &absinfo);
     if (ret == -1) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -362,7 +362,7 @@ ioctl_EVIOCGRAB(PyObject *self, PyObject *args)
 
     ret = ioctl(fd, EVIOCGRAB, (intptr_t)flag);
     if (ret != 0) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -485,7 +485,7 @@ upload_effect(PyObject *self, PyObject *args)
 
     ret = ioctl(fd, EVIOCSFF, &effect);
     if (ret != 0) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -504,7 +504,7 @@ erase_effect(PyObject *self, PyObject *args)
     long ff_id = PyLong_AsLong(ff_id_obj);
     ret = ioctl(fd, EVIOCRMFF, ff_id);
     if (ret != 0) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 

--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -97,6 +97,24 @@ uinput_set_prop(PyObject *self, PyObject *args)
         return NULL;
 }
 
+static PyObject *
+uinput_get_sysname(PyObject *self, PyObject *args)
+{
+    int fd;
+    char sysname[64];
+
+    int ret = PyArg_ParseTuple(args, "i", &fd);
+    if (!ret) return NULL;
+
+    if (ioctl(fd, UI_GET_SYSNAME(sizeof(sysname)), &sysname) < 0)
+        goto on_err;
+
+    return Py_BuildValue("s", &sysname);
+
+    on_err:
+        PyErr_SetFromErrno(PyExc_IOError);
+        return NULL;
+}
 
 // Different kernel versions have different device setup methods. You can read
 // more about it here:
@@ -360,6 +378,9 @@ static PyMethodDef MethodTable[] = {
 
     { "set_phys", uinput_set_phys, METH_VARARGS,
       "Set physical path"},
+
+    { "get_sysname", uinput_get_sysname, METH_VARARGS,
+      "Obtain the sysname of the uinput device."},
 
     { "set_prop", uinput_set_prop, METH_VARARGS,
       "Set device input property"},

--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -49,7 +49,7 @@ uinput_open(PyObject *self, PyObject *args)
 
     int fd = open(devnode, O_RDWR | O_NONBLOCK);
     if (fd < 0) {
-        PyErr_SetString(PyExc_IOError, "could not open uinput device in write mode");
+        PyErr_SetString(PyExc_OSError, "could not open uinput device in write mode");
         return NULL;
     }
 
@@ -73,7 +73,7 @@ uinput_set_phys(PyObject *self, PyObject *args)
 
     on_err:
         _uinput_close(fd);
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -93,7 +93,7 @@ uinput_set_prop(PyObject *self, PyObject *args)
 
     on_err:
         _uinput_close(fd);
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -112,7 +112,7 @@ uinput_get_sysname(PyObject *self, PyObject *args)
     return Py_BuildValue("s", &sysname);
 
     on_err:
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -175,7 +175,7 @@ uinput_setup(PyObject *self, PyObject *args) {
 
     on_err:
         _uinput_close(fd);
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -224,7 +224,7 @@ uinput_setup(PyObject *self, PyObject *args) {
 
     on_err:
         _uinput_close(fd);
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 #endif
@@ -245,7 +245,7 @@ uinput_create(PyObject *self, PyObject *args)
 
     on_err:
         _uinput_close(fd);
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 
@@ -259,7 +259,7 @@ uinput_close(PyObject *self, PyObject *args)
     if (!ret) return NULL;
 
     if (_uinput_close(fd) < 0) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -287,8 +287,8 @@ uinput_write(PyObject *self, PyObject *args)
 
     if (write(fd, &event, sizeof(event)) != sizeof(event)) {
         // @todo: elaborate
-        // PyErr_SetString(PyExc_IOError, "error writing event to uinput device");
-        PyErr_SetFromErrno(PyExc_IOError);
+        // PyErr_SetString(PyExc_OSError, "error writing event to uinput device");
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
@@ -330,7 +330,7 @@ uinput_enable_event(PyObject *self, PyObject *args)
 
     on_err:
         _uinput_close(fd);
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
 }
 

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -328,7 +328,21 @@ class UInput(EventIO):
         #:bug: the device node might not be immediately available
         time.sleep(0.1)
 
+        # Strictly speaking, we cannot be certain that everything returned by list_devices()
+        # ends at event[0-9]+: it might return something like "/dev/input/events_all". Find
+        # the devices that have the expected structure and extract their device number.
+        path_number_pairs = []
+        regex = re.compile('/dev/input/event([0-9]+)')
         for path in util.list_devices('/dev/input/'):
+            regex_match = regex.fullmatch(path)
+            if not regex_match:
+                continue
+            device_number = int(regex_match[1])
+            path_number_pairs.append((path, device_number))
+
+        path_number_pairs.sort(key=lambda pair: pair[1], reverse=True)
+
+        for (path, _) in path_number_pairs:
             d = device.InputDevice(path)
             if d.name == self.name:
                 return d

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -288,18 +288,14 @@ class UInput(EventIO):
         Tries to find the device node. Will delegate this task to one of
         several platform-specific functions.
         '''
-        try:
-            sysname = _uinput.get_sysname(fd)
-        except OSError:
-            # UI_GET_SYSNAME returned an error code. We're likely dealing with
-            # an old kernel. Guess the device based on the filesystem.
-            return self._find_device_fallback()
-
-        try:
-            if platform.system() == 'Linux':
+        if platform.system() == 'Linux':
+            try:
+                sysname = _uinput.get_sysname(fd)
                 return self._find_device_linux(sysname)
-        except OSError:
-            pass
+            except OSError:
+                # UI_GET_SYSNAME returned an error code. We're likely dealing with
+                # an old kernel. Guess the device based on the filesystem.
+                pass
 
         # If we're not running or Linux or the above method fails for any reason,
         # use the generic fallback method.

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -349,6 +349,8 @@ class UInput(EventIO):
             device_number = int(regex_match[1])
             path_number_pairs.append((path, device_number))
 
+        # The modification date of the devnode is not reliable unfortunately, so we
+        # are sorting by the number in the name
         path_number_pairs.sort(key=lambda pair: pair[1], reverse=True)
 
         for (path, _) in path_number_pairs:

--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -337,6 +337,8 @@ class UInput(EventIO):
         #:bug: the device node might not be immediately available
         time.sleep(0.1)
 
+        # There could also be another device with the same name already present,
+        # make sure to select the newest one.
         # Strictly speaking, we cannot be certain that everything returned by list_devices()
         # ends at event[0-9]+: it might return something like "/dev/input/events_all". Find
         # the devices that have the expected structure and extract their device number.


### PR DESCRIPTION
As discussed in issue #205. Finds the device node on Linux systems that support UI_GET_SYSNAME in the same way that libevdev does.

I haven't implemented the FreeBSD variant of the logic yet because (1) then I'd have to set up a FreeBSD VM to test it, and (2) the documentation of python-evdev does not even mention FreeBSD as a supported platform. That said, the FreeBSD variant of the function `_find_device_linux` should literally be a simple as:

```py
def _find_device_freebsd(self, sysname):
    return device.InputDevice(f'/dev/input/{sysname}')
```

There is some discussion about how the code of `_find_device_fallback` should be updated in issue #204 and #205. This pull request does not integrate those proposed changes.

