### PR TITLE
Add #ifdef guards around UI_GET_SYSNAME

### DIFF
--- a/evdev/uinput.c
+++ b/evdev/uinput.c
@@ -106,10 +106,12 @@ uinput_get_sysname(PyObject *self, PyObject *args)
     int ret = PyArg_ParseTuple(args, "i", &fd);
     if (!ret) return NULL;
 
+    #ifdef UI_GET_SYSNAME
     if (ioctl(fd, UI_GET_SYSNAME(sizeof(sysname)), &sysname) < 0)
         goto on_err;
 
     return Py_BuildValue("s", &sysname);
+    #endif
 
     on_err:
         PyErr_SetFromErrno(PyExc_OSError);


### PR DESCRIPTION
The Python code is already ready to deal with `uinput_get_sysname()` throwing OSError in case the ioctl `UI_GET_SYSNAME` is not available, but it turns out that the C object code refuses to link if the macro `UI_GET_SYSNAME` was not defined at build time, because the compiler assumes that `UI_GET_SYSNAME` is a symbol that will be defined later at link time. (Issue #178)

Add an `#ifdef` guard around the code that relies on `UI_GET_SYSNAME` so that no reference to any hypothetical symbol `UI_GET_SYSNAME` remains in the object code if the `UI_GET_SYSNAME` macro was undefined at build time. This will cause `uinput_get_sysname()` to raise OSError if the `UI_GET_SYSNAME` was not defined at build time.