### PR TITLE
Provide fallback value for FF_MAX_EFFECTS

### DIFF
--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -90,7 +90,10 @@ class UInput(EventIO):
         devnode="/dev/uinput",
         phys="py-evdev-uinput",
         input_props=None,
-        max_effects=ecodes.FF_MAX_EFFECTS,
+        # CentOS 7 has sufficiently old headers that FF_MAX_EFFECTS is not defined there,
+        # which causes the whole module to fail loading. Fallback on a hardcoded value of
+        # FF_MAX_EFFECTS if it is not defined in the ecodes.
+        max_effects=ecodes.ecodes.get("FF_MAX_EFFECTS", 96),
     ):
         """
         Arguments


### PR DESCRIPTION
This is required to make python-evdev work on CentOS 7. On CentOS 7, the ecode `FF_MAX_EFFECTS` is not defined, which means that the function definition of `UInput.__init__` fails to run, which causes the whole module to break on import.