### PR TITLE
Small character device verification cleanup

### DIFF
--- a/evdev/uinput.py
+++ b/evdev/uinput.py
@@ -272,7 +272,7 @@ class UInput(EventIO):
             m = os.stat(self.devnode)[stat.ST_MODE]
             assert stat.S_ISCHR(m)
         except (IndexError, OSError, AssertionError):
-            msg = '"{}" does not exist or is not a character device file ' "- verify that the uinput module is loaded"
+            msg = '"{}" does not exist or is not a character device file - verify that the uinput module is loaded'
             raise UInputError(msg.format(self.devnode))
 
         if not os.access(self.devnode, os.W_OK):

--- a/tests/test_uinput.py
+++ b/tests/test_uinput.py
@@ -2,7 +2,7 @@
 import os
 import stat
 from select import select
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 from pytest import raises, fixture

--- a/tests/test_uinput.py
+++ b/tests/test_uinput.py
@@ -1,7 +1,8 @@
 # encoding: utf-8
+import os
 import stat
 from select import select
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 from pytest import raises, fixture
@@ -119,6 +120,18 @@ def test_write(c):
 
 
 @patch.object(stat, 'S_ISCHR', return_value=False)
-def test_not_a_character_device(c):
-    with pytest.raises(UInputError):
+def test_not_a_character_device(ischr_mock, c):
+    with pytest.raises(UInputError, match='not a character device file'):
+        uinput.UInput(**c)
+
+@patch.object(stat, 'S_ISCHR', return_value=True)
+@patch.object(os, 'stat', side_effect=OSError())
+def test_not_a_character_device_2(stat_mock, ischr_mock, c):
+    with pytest.raises(UInputError, match='not a character device file'):
+        uinput.UInput(**c)
+
+@patch.object(stat, 'S_ISCHR', return_value=True)
+@patch.object(os, 'stat', return_value=[])
+def test_not_a_character_device_3(stat_mock, ischr_mock, c):
+    with pytest.raises(UInputError, match='not a character device file'):
         uinput.UInput(**c)


### PR DESCRIPTION
Followup for https://github.com/gvalkov/python-evdev/pull/228

~Because the quick fix for the `raise` is still, in some way, using exceptions for control flow, and I don't like raising some exception just to replace it with a different one shortly afterwards. Also, OSError is wrong there and just happened to work for the time being. I also wanted to avoid solutions that define msg multiple times (inside the if, and inside the except), and avoid creating/formatting msg before any exception happened. So it had to be `except: pass` to raise the exception at the end of the method. This is somewhat hard to get beautiful and good-practice.~

edit: looks pretty with assert.

Added 2 more tests.