### PR TITLE
Explicit export

### DIFF
--- a/src/evdev/__init__.py
+++ b/src/evdev/__init__.py
@@ -2,8 +2,25 @@
 # Gather everything into a single, convenient namespace.
 # --------------------------------------------------------------------------
 
-from . import ecodes, ff
-from .device import AbsInfo, DeviceInfo, EvdevError, InputDevice
-from .events import AbsEvent, InputEvent, KeyEvent, RelEvent, SynEvent, event_factory
-from .uinput import UInput, UInputError
-from .util import categorize, list_devices, resolve_ecodes, resolve_ecodes_dict
+from . import ecodes as ecodes, ff as ff
+from .device import (
+    AbsInfo as AbsInfo,
+    DeviceInfo as DeviceInfo,
+    EvdevError as EvdevError,
+    InputDevice as InputDevice,
+)
+from .events import (
+    AbsEvent as AbsEvent,
+    InputEvent as InputEvent,
+    KeyEvent as KeyEvent,
+    RelEvent as RelEvent,
+    SynEvent as SynEvent,
+    event_factory as event_factory,
+)
+from .uinput import UInput as UInput, UInputError as UInputError
+from .util import (
+    categorize as categorize,
+    list_devices as list_devices,
+    resolve_ecodes as resolve_ecodes,
+    resolve_ecodes_dict as resolve_ecodes_dict,
+)


### PR DESCRIPTION
Fixes type errors such as:
```
compatibility_device.py:4: error: Module "evdev" does not explicitly export attribute "InputDevice"  [attr-defined]
compatibility_device.py:4: error: Module "evdev" does not explicitly export attribute "categorize"  [attr-defined]
```

Alternative approach is to define `__all__` and list everything in there.