### PR TITLE
Add ft support

### DIFF
--- a/src/evdev/genecodes_c.py
+++ b/src/evdev/genecodes_c.py
@@ -77,6 +77,9 @@ PyInit__ecodes(void)
 {
     PyObject* m = PyModule_Create(&moduledef);
     if (m == NULL) return NULL;
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
 
 %s
 

--- a/src/evdev/input.c
+++ b/src/evdev/input.c
@@ -51,7 +51,10 @@ device_read(PyObject *self, PyObject *args)
     // get device file descriptor (O_RDONLY|O_NONBLOCK)
     int fd = (int)PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
 
-    int n = read(fd, &event, sizeof(event));
+    int n;
+    Py_BEGIN_ALLOW_THREADS
+    n = read(fd, &event, sizeof(event));
+    Py_END_ALLOW_THREADS
 
     if (n < 0) {
         if (errno == EAGAIN) {
@@ -84,7 +87,10 @@ device_read_many(PyObject *self, PyObject *args)
     struct input_event event[64];
 
     size_t event_size = sizeof(struct input_event);
-    ssize_t nread = read(fd, event, event_size*64);
+    ssize_t nread;
+    Py_BEGIN_ALLOW_THREADS
+    nread = read(fd, event, event_size*64);
+    Py_END_ALLOW_THREADS
 
     if (nread < 0) {
         PyErr_SetFromErrno(PyExc_OSError);
@@ -570,6 +576,9 @@ moduleinit(void)
 {
     PyObject* m = PyModule_Create(&moduledef);
     if (m == NULL) return NULL;
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
     return m;
 }
 

--- a/src/evdev/uinput.c
+++ b/src/evdev/uinput.c
@@ -405,7 +405,9 @@ moduleinit(void)
 {
     PyObject* m = PyModule_Create(&moduledef);
     if (m == NULL) return NULL;
-
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
     PyModule_AddIntConstant(m, "maxnamelen", UINPUT_MAX_NAME_SIZE);
     return m;
 }


### PR DESCRIPTION
Closes #256 

before

```sh
> uv venv /tmp/test-main-ft --python 3.13t
Using CPython 3.13.12+freethreaded interpreter at: .local/bin/python3.13t
Creating virtual environment at: /tmp/test-main-ft
Activate with: source /tmp/test-main-ft/bin/activate
~                                                                      py test-git-ft fedemengo@fedora 14:43:30
> source /tmp/test-git-ft/bin/activate
~                                                                      py test-git-ft fedemengo@fedora 13:28:54
> uv pip install evdev
Using Python 3.13.12 environment at: /tmp/test-main-ft
Resolved 1 package in 175ms
      Built evdev==1.9.3
Prepared 1 package in 985ms
░░░░░░░░░░░░░░░░░░░░ [0/1] Installing wheels...                                                                 warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 1 package in 0.80ms
 + evdev==1.9.3
~                                                                     py test-main-ft fedemengo@fedora 14:44:46
> python -c "import sys
print('free-threaded build:', not sys._is_gil_enabled())  # starts False in ft build
import evdev
print('GIL after import:', sys._is_gil_enabled())  # should still be False with fix"
free-threaded build: True
<frozen importlib._bootstrap>:488: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'evdev._input', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
GIL after import: True
```

after

```sh
> uv venv /tmp/test-ft --python 3.13t
Using CPython 3.13.12+freethreaded interpreter at: .local/bin/python3.13t
Creating virtual environment at: /tmp/test-ft
Activate with: source /tmp/test-ft/bin/activate
~                                                                                     fedemengo@fedora 13:25:17
> source /tmp/test-ft/bin/activate
~                                                                          py test-ft fedemengo@fedora 13:25:21
> uv pip install /tmp/python-evdev
Using Python 3.13.12 environment at: /tmp/test-ft
Resolved 1 package in 10ms
      Built evdev @ file:///tmp/python-evdev
Prepared 1 package in 1.44s
░░░░░░░░░░░░░░░░░░░░ [0/1] Installing wheels...                                                                 warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 1 package in 0.84ms
 + evdev==1.9.3 (from file:///tmp/python-evdev)

> python -c "import sys
print('free-threaded build:', not sys._is_gil_enabled())  # starts False in ft build
import evdev
print('GIL after import:', sys._is_gil_enabled())  # should still be False with fix"
free-threaded build: True
GIL after import: False
```