### PR TITLE
fix asyncio deprecation warning

### DIFF
--- a/src/evdev/eventio_async.py
+++ b/src/evdev/eventio_async.py
@@ -36,7 +36,7 @@ class ReadIterator:
         return self
 
     def __anext__(self) -> "asyncio.Future[InputEvent]":
-        future = asyncio.Future()
+        future = asyncio.get_running_loop().create_future()
         try:
             # Read from the previous batch of events.
             future.set_result(next(self.current_batch))
@@ -55,7 +55,10 @@ class ReadIterator:
 
 class EventIO(eventio.EventIO):
     def _do_when_readable(self, callback):
-        loop = asyncio.get_event_loop()
+        # Remember the loop the reader is registered on so that close() can
+        # remove it later, even when called without a running event loop.
+        loop = asyncio.get_running_loop()
+        self._loop = loop
 
         def ready():
             loop.remove_reader(self.fileno())
@@ -74,7 +77,7 @@ class EventIO(eventio.EventIO):
         Asyncio coroutine to read and return a single input event as
         an instance of :class:`InputEvent <evdev.events.InputEvent>`.
         """
-        future = asyncio.Future()
+        future = asyncio.get_running_loop().create_future()
         self._do_when_readable(lambda: self._set_result(future, self.read_one))
         return future
 
@@ -84,7 +87,7 @@ class EventIO(eventio.EventIO):
         a generator object that yields :class:`InputEvent <evdev.events.InputEvent>`
         instances.
         """
-        future = asyncio.Future()
+        future = asyncio.get_running_loop().create_future()
         self._do_when_readable(lambda: self._set_result(future, self.read))
         return future
 
@@ -97,10 +100,11 @@ class EventIO(eventio.EventIO):
         return ReadIterator(self)
 
     def close(self):
-        try:
-            loop = asyncio.get_event_loop()
-            loop.remove_reader(self.fileno())
-        except RuntimeError:
-            # no event loop present, so there is nothing to
-            # remove the reader from. Ignore
-            pass
+        # A reader is only registered once an async read has been awaited, in
+        # which case _do_when_readable recorded the loop it was added to.
+        loop = getattr(self, "_loop", None)
+        if loop is None or loop.is_closed():
+            # No reader was ever registered, or its loop is already gone, so
+            # there is nothing to remove the reader from.
+            return
+        loop.remove_reader(self.fileno())

--- a/src/evdev/eventio_async.py
+++ b/src/evdev/eventio_async.py
@@ -54,6 +54,10 @@ class ReadIterator:
 
 
 class EventIO(eventio.EventIO):
+    # The event loop a reader was last registered on, or None if no async read
+    # has been awaited yet. Set in _do_when_readable, used by close().
+    _loop: "asyncio.AbstractEventLoop | None" = None
+
     def _do_when_readable(self, callback):
         # Remember the loop the reader is registered on so that close() can
         # remove it later, even when called without a running event loop.
@@ -102,7 +106,7 @@ class EventIO(eventio.EventIO):
     def close(self):
         # A reader is only registered once an async read has been awaited, in
         # which case _do_when_readable recorded the loop it was added to.
-        loop = getattr(self, "_loop", None)
+        loop = self._loop
         if loop is None or loop.is_closed():
             # No reader was ever registered, or its loop is already gone, so
             # there is nothing to remove the reader from.


### PR DESCRIPTION
## Summary

`eventio_async.py` relies on two asyncio APIs that are deprecated when called without a running event loop, and will emit a DeprecationWarning on any code that doesn't use the `aync_read_*` methods. 

- `asyncio.Future()` — implicitly binds to the current loop via `get_event_loop()`.
- `asyncio.get_event_loop()` — emits a `DeprecationWarning` on Python 3.10+ (and is slated for removal) when there is no running loop.

Replaced with:

- `asyncio.get_running_loop().create_future()` for creating futures (`ReadIterator.__anext__`, `async_read_one`, `async_read`).
- `asyncio.get_running_loop()` in `_do_when_readable`, caching the loop on `self._loop` so `close()` can later remove the reader from the exact loop it was registered on.

## Behavior change

The old code tolerated building a read future before any loop was running. The new code must now be called from within a running loop, otherwise it will raise `RuntimeError: no running event loop`. Normal `async for` / `await` usage inside a coroutine is unaffected. I looked around at how this code is used in public repos (notably [Home Assistant](https://github.com/home-assistant/core/blob/134b1cbc4f26edad5d7ec148f9b89e7083345abf/homeassistant/components/keyboard_remote/__init__.py#L339)), and it appeared that nothing would break. 

## Testing

I wrote up a couple of example scripts (reading events via `async_read_loop`, `async_read_one`, and `async_read`), and confirmed the deprecation warnings no longer appear and events from a keyboard are read properly.